### PR TITLE
Feature/55 post chat room

### DIFF
--- a/src/main/java/com/sptp/backend/chat_room/repository/ChatRoom.java
+++ b/src/main/java/com/sptp/backend/chat_room/repository/ChatRoom.java
@@ -15,6 +15,9 @@ import javax.persistence.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Table(uniqueConstraints = {@UniqueConstraint(
+        name = "CHAT_ROOM_UNIQUE",
+        columnNames = {"artist_id", "member_id", "art_work_id"})})
 public class ChatRoom extends BaseEntity {
 
     @Id
@@ -27,8 +30,8 @@ public class ChatRoom extends BaseEntity {
     private Member artist;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "collector_id")
-    private Member collector;
+    @JoinColumn(name = "member_id")
+    private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "art_work_id")

--- a/src/main/java/com/sptp/backend/chat_room/repository/ChatRoomRepository.java
+++ b/src/main/java/com/sptp/backend/chat_room/repository/ChatRoomRepository.java
@@ -2,5 +2,8 @@ package com.sptp.backend.chat_room.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+    Optional<ChatRoom> findByMemberIdAndArtistIdAndArtWorkId(Long artistId, Long MemberId, Long artWorkId);
 }

--- a/src/main/java/com/sptp/backend/chat_room/service/ChatRoomService.java
+++ b/src/main/java/com/sptp/backend/chat_room/service/ChatRoomService.java
@@ -29,7 +29,34 @@ public class ChatRoomService {
     private final ArtWorkRepository artWorkRepository;
     private final MessageRepository messageRepository;
 
-    
+    public long createChatRoom(Long loginMemberId, Long artistId, Long artWorkId) {
+
+        Optional<ChatRoom> chatRoomOptional =
+                chatRoomRepository.findByMemberIdAndArtistIdAndArtWorkId(loginMemberId, artistId, artWorkId);
+
+        // 기존 채팅방이 존재하는 경우 해당 id 반환
+        if (chatRoomOptional.isPresent()) {
+            return chatRoomOptional.get().getId();
+        }
+
+        ChatRoom chatRoom = ChatRoom.builder()
+                .member(getMember(loginMemberId))
+                .artist(getMember(artistId))
+                .artWork(getArtWork(artWorkId))
+                .build();
+
+        return chatRoomRepository.save(chatRoom).getId();
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));
+    }
+
+    private ArtWork getArtWork(Long artistId) {
+        return artWorkRepository.findById(artistId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ARTWORK));
+    }
 
     public ChatRoomDetailResponse getChatRoomDetail(Long chatRoomId) {
 

--- a/src/main/java/com/sptp/backend/chat_room/service/ChatRoomService.java
+++ b/src/main/java/com/sptp/backend/chat_room/service/ChatRoomService.java
@@ -1,13 +1,11 @@
 package com.sptp.backend.chat_room.service;
 
-import com.sptp.backend.art_work.repository.ArtWork;
 import com.sptp.backend.art_work.repository.ArtWorkRepository;
 import com.sptp.backend.chat_room.repository.ChatRoom;
 import com.sptp.backend.chat_room.repository.ChatRoomRepository;
 import com.sptp.backend.chat_room.web.dto.ChatRoomDetailResponse;
 import com.sptp.backend.common.exception.CustomException;
 import com.sptp.backend.common.exception.ErrorCode;
-import com.sptp.backend.member.repository.Member;
 import com.sptp.backend.member.repository.MemberRepository;
 import com.sptp.backend.message.repository.Message;
 import com.sptp.backend.message.repository.MessageRepository;
@@ -40,22 +38,15 @@ public class ChatRoomService {
         }
 
         ChatRoom chatRoom = ChatRoom.builder()
-                .member(getMember(loginMemberId))
-                .artist(getMember(artistId))
-                .artWork(getArtWork(artWorkId))
+                .member(memberRepository.findById(loginMemberId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER)))
+                .artist(memberRepository.findById(artistId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ARTIST)))
+                .artWork(artWorkRepository.findById(artWorkId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ARTWORK)))
                 .build();
 
         return chatRoomRepository.save(chatRoom).getId();
-    }
-
-    private Member getMember(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_MEMBER));
-    }
-
-    private ArtWork getArtWork(Long artistId) {
-        return artWorkRepository.findById(artistId)
-                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ARTWORK));
     }
 
     public ChatRoomDetailResponse getChatRoomDetail(Long chatRoomId) {

--- a/src/main/java/com/sptp/backend/chat_room/service/ChatRoomService.java
+++ b/src/main/java/com/sptp/backend/chat_room/service/ChatRoomService.java
@@ -1,0 +1,50 @@
+package com.sptp.backend.chat_room.service;
+
+import com.sptp.backend.art_work.repository.ArtWork;
+import com.sptp.backend.art_work.repository.ArtWorkRepository;
+import com.sptp.backend.chat_room.repository.ChatRoom;
+import com.sptp.backend.chat_room.repository.ChatRoomRepository;
+import com.sptp.backend.chat_room.web.dto.ChatRoomDetailResponse;
+import com.sptp.backend.common.exception.CustomException;
+import com.sptp.backend.common.exception.ErrorCode;
+import com.sptp.backend.member.repository.Member;
+import com.sptp.backend.member.repository.MemberRepository;
+import com.sptp.backend.message.repository.Message;
+import com.sptp.backend.message.repository.MessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatRoomService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final MemberRepository memberRepository;
+    private final ArtWorkRepository artWorkRepository;
+    private final MessageRepository messageRepository;
+
+    
+
+    public ChatRoomDetailResponse getChatRoomDetail(Long chatRoomId) {
+
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_CHAT_ROOM));
+        List<Message> messages = messageRepository.findAllByChatRoomOrderByIdAsc(chatRoom);
+
+        return ChatRoomDetailResponse.builder()
+                .chatRoomId(chatRoomId)
+                .artist(ChatRoomDetailResponse.MemberDto.from(chatRoom.getArtist()))
+                .member(ChatRoomDetailResponse.MemberDto.from(chatRoom.getMember()))
+                .messages(messages.stream()
+                        .map(ChatRoomDetailResponse.MessageDto::from)
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+}

--- a/src/main/java/com/sptp/backend/chat_room/web/ChatRoomController.java
+++ b/src/main/java/com/sptp/backend/chat_room/web/ChatRoomController.java
@@ -1,0 +1,29 @@
+package com.sptp.backend.chat_room.web;
+
+import com.sptp.backend.chat_room.service.ChatRoomService;
+import com.sptp.backend.chat_room.web.dto.ChatRoomCreateRequest;
+import com.sptp.backend.chat_room.web.dto.ChatRoomDetailResponse;
+import com.sptp.backend.jwt.service.dto.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.apache.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/chat-rooms")
+public class ChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+
+
+    @GetMapping("/{chatRoomId}")
+    public ResponseEntity<ChatRoomDetailResponse> getChatRoomDetail(@PathVariable Long chatRoomId) {
+
+        return ResponseEntity.ok(chatRoomService.getChatRoomDetail(chatRoomId));
+    }
+}

--- a/src/main/java/com/sptp/backend/chat_room/web/ChatRoomController.java
+++ b/src/main/java/com/sptp/backend/chat_room/web/ChatRoomController.java
@@ -20,6 +20,16 @@ public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
 
+    @PostMapping
+    public ResponseEntity<Void> createChatRoom(@Valid @RequestBody ChatRoomCreateRequest chatRoomCreateRequest,
+                                            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        long chatRoomId = chatRoomService.createChatRoom(userDetails.getMember().getId(),
+                chatRoomCreateRequest.getArtistId(), chatRoomCreateRequest.getArtWorkId());
+
+        return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY)
+                .header(HttpHeaders.LOCATION, "/chat-rooms/" + chatRoomId).build();
+    }
 
     @GetMapping("/{chatRoomId}")
     public ResponseEntity<ChatRoomDetailResponse> getChatRoomDetail(@PathVariable Long chatRoomId) {

--- a/src/main/java/com/sptp/backend/chat_room/web/dto/ChatRoomCreateRequest.java
+++ b/src/main/java/com/sptp/backend/chat_room/web/dto/ChatRoomCreateRequest.java
@@ -1,0 +1,21 @@
+package com.sptp.backend.chat_room.web.dto;
+
+import com.sptp.backend.art_work.repository.ArtWork;
+import com.sptp.backend.member.repository.Member;
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatRoomCreateRequest {
+
+    @NotNull(message = "작가 고유 번호는 필수입니다.")
+    private Long artistId;
+
+    @NotNull(message = "작품 고유 번호는 필수입니다.")
+    private Long artWorkId;
+}

--- a/src/main/java/com/sptp/backend/chat_room/web/dto/ChatRoomDetailResponse.java
+++ b/src/main/java/com/sptp/backend/chat_room/web/dto/ChatRoomDetailResponse.java
@@ -1,0 +1,52 @@
+package com.sptp.backend.chat_room.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.sptp.backend.member.repository.Member;
+import com.sptp.backend.message.repository.Message;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+public class ChatRoomDetailResponse {
+
+    private Long chatRoomId;
+    private MemberDto artist;
+    private MemberDto member;
+    private List<MessageDto> messages;
+
+    @Data
+    @Builder
+    public static class MemberDto {
+        private Long id;
+        private String name;
+//        private String responseTime; 추후 구현 예정
+
+        public static MemberDto from(Member member) {
+            return MemberDto.builder()
+                    .id(member.getId())
+                    .name(member.getNickname())
+                    .build();
+        }
+    }
+
+    @Data
+    @Builder
+    public static class MessageDto {
+        private Long senderId;
+        private String message;
+
+        @JsonFormat(pattern = "yyyy-MM-dd-HH-mm-ss")
+        private LocalDateTime sendTime;
+
+        public static MessageDto from(Message message) {
+            return MessageDto.builder()
+                    .senderId(message.getSender().getId())
+                    .message(message.getMessage())
+                    .sendTime(message.getCreatedDate())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/sptp/backend/message/repository/MessageRepository.java
+++ b/src/main/java/com/sptp/backend/message/repository/MessageRepository.java
@@ -1,6 +1,13 @@
 package com.sptp.backend.message.repository;
 
+import com.sptp.backend.chat_room.repository.ChatRoom;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MessageRepository extends JpaRepository<Message, Long> {
+
+    @EntityGraph(attributePaths = {"sender"})
+    List<Message> findAllByChatRoomOrderByIdAsc(ChatRoom chatRom);
 }

--- a/src/test/java/com/sptp/backend/chat_room/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/sptp/backend/chat_room/service/ChatRoomServiceTest.java
@@ -1,0 +1,172 @@
+package com.sptp.backend.chat_room.service;
+
+import com.sptp.backend.art_work.repository.ArtWork;
+import com.sptp.backend.art_work.repository.ArtWorkRepository;
+import com.sptp.backend.chat_room.repository.ChatRoom;
+import com.sptp.backend.chat_room.repository.ChatRoomRepository;
+import com.sptp.backend.common.exception.CustomException;
+import com.sptp.backend.common.exception.ErrorCode;
+import com.sptp.backend.member.repository.Member;
+import com.sptp.backend.member.repository.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomServiceTest {
+
+    @InjectMocks
+    ChatRoomService chatRoomService;
+
+    @Mock
+    ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Mock
+    ArtWorkRepository artWorkRepository;
+
+    @Nested
+    class createChatRoomTest {
+
+        long artistId = 1L;
+        long memberId = 2L;
+        long artWorkId = 4L;
+        long chatRoomId = 4L;
+        Member artist;
+        Member member;
+        ArtWork artWork;
+        ChatRoom chatRoom;
+
+        @BeforeEach
+        void init() {
+            artist = Member.builder()
+                    .id(artistId)
+                    .userId("artist")
+                    .password("12345678")
+                    .build();
+
+            member = Member.builder()
+                    .id(memberId)
+                    .userId("member")
+                    .password("12345678")
+                    .build();
+
+            artWork = ArtWork.builder()
+                    .id(artWorkId)
+                    .build();
+
+            chatRoom = ChatRoom.builder()
+                    .id(chatRoomId)
+                    .artist(artist)
+                    .member(member)
+                    .artWork(artWork)
+                    .build();
+        }
+
+        @Test
+        void successWhenChatRoomIsPresent() {
+            //given
+            when(chatRoomRepository.findByMemberIdAndArtistIdAndArtWorkId(anyLong(), anyLong(), anyLong()))
+                    .thenReturn(Optional.of(chatRoom));
+
+            //when
+            //then
+            assertThatNoException().isThrownBy(() -> chatRoomService.createChatRoom(memberId, artistId, artWorkId));
+        }
+
+        @Test
+        void successWhenChatRoomIsNotPresent() {
+            //given
+            when(chatRoomRepository.findByMemberIdAndArtistIdAndArtWorkId(anyLong(), anyLong(), anyLong()))
+                    .thenReturn(Optional.empty());
+
+            when(memberRepository.findById(memberId))
+                    .thenReturn(Optional.of(member));
+
+            when(memberRepository.findById(artistId))
+                    .thenReturn(Optional.of(artist));
+
+            when(artWorkRepository.findById(artWorkId))
+                    .thenReturn(Optional.of(artWork));
+
+            when(chatRoomRepository.save(any(ChatRoom.class)))
+                    .thenReturn(chatRoom);
+
+            //when
+            //then
+            assertThatNoException().isThrownBy(() -> chatRoomService.createChatRoom(memberId, artistId, artWorkId));
+        }
+
+        @Test
+        void failByNotFoundLoginMember() {
+            //given
+            when(chatRoomRepository.findByMemberIdAndArtistIdAndArtWorkId(anyLong(), anyLong(), anyLong()))
+                    .thenReturn(Optional.empty());
+
+            when(memberRepository.findById(memberId))
+                    .thenReturn(Optional.empty());
+
+            //when
+            //then
+            assertThatThrownBy(() -> chatRoomService.createChatRoom(memberId, artistId, artWorkId))
+                    .isInstanceOf(CustomException.class)
+                    .message().isEqualTo(ErrorCode.NOT_FOUND_MEMBER.getDetail());
+        }
+
+        @Test
+        void failByNotFoundArtist() {
+            //given
+            when(chatRoomRepository.findByMemberIdAndArtistIdAndArtWorkId(anyLong(), anyLong(), anyLong()))
+                    .thenReturn(Optional.empty());
+
+            when(memberRepository.findById(memberId))
+                    .thenReturn(Optional.of(member));
+
+            when(memberRepository.findById(artistId))
+                    .thenReturn(Optional.empty());
+
+            //when
+            //then
+            assertThatThrownBy(() -> chatRoomService.createChatRoom(memberId, artistId, artWorkId))
+                    .isInstanceOf(CustomException.class)
+                    .message().isEqualTo(ErrorCode.NOT_FOUND_ARTIST.getDetail());
+        }
+
+        @Test
+        void failByNotFoundArtWork() {
+            //given
+            when(chatRoomRepository.findByMemberIdAndArtistIdAndArtWorkId(anyLong(), anyLong(), anyLong()))
+                    .thenReturn(Optional.empty());
+
+            when(memberRepository.findById(memberId))
+                    .thenReturn(Optional.of(member));
+
+            when(memberRepository.findById(artistId))
+                    .thenReturn(Optional.of(artist));
+
+            when(artWorkRepository.findById(artWorkId))
+                    .thenReturn(Optional.empty());
+
+            //when
+            //then
+            assertThatThrownBy(() -> chatRoomService.createChatRoom(memberId, artistId, artWorkId))
+                    .isInstanceOf(CustomException.class)
+                    .message().isEqualTo(ErrorCode.NOT_FOUND_ARTWORK.getDetail());
+        }
+    }
+
+}

--- a/src/test/java/com/sptp/backend/message/repository/MessageRepositoryTest.java
+++ b/src/test/java/com/sptp/backend/message/repository/MessageRepositoryTest.java
@@ -1,0 +1,62 @@
+package com.sptp.backend.message.repository;
+
+import com.sptp.backend.chat_room.repository.ChatRoom;
+import com.sptp.backend.common.config.DBConfig;
+import com.sptp.backend.common.config.PropertyConfig;
+import com.sptp.backend.common.entity.BaseEntity;
+import com.sptp.backend.member.repository.Member;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import javax.persistence.EntityManager;
+
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@Import({DBConfig.class, PropertyConfig.class})
+class MessageRepositoryTest {
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Autowired
+    MessageRepository messageRepository;
+
+    ChatRoom chatRoom;
+    int messageCount = 5;
+
+    @BeforeEach
+    void init() {
+        chatRoom = ChatRoom.builder().build();
+
+        entityManager.persist(chatRoom);
+
+        for (int i = 0; i < messageCount; i++) {
+            entityManager.persist(Message.builder()
+                    .message("테스트 메시지")
+                    .chatRoom(chatRoom)
+                    .build());
+            ;
+        }
+    }
+
+    @Test
+    void findAllByChatRoomOrderByCreatedDateAsc() {
+        //given
+        //when
+        List<Message> messages = messageRepository.findAllByChatRoomOrderByIdAsc(chatRoom);
+
+        //then
+        assertThat(messages).hasSize(messageCount);
+        assertThat(messages).isSortedAccordingTo(Comparator.comparing(Message::getId)); // id 오름차순 검증
+    }
+}

--- a/src/test/java/com/sptp/backend/message/service/MessageServiceTest.java
+++ b/src/test/java/com/sptp/backend/message/service/MessageServiceTest.java
@@ -1,6 +1,6 @@
 package com.sptp.backend.message.service;
 
-import com.sptp.backend.artwork.repository.ArtWork;
+import com.sptp.backend.art_work.repository.ArtWork;
 import com.sptp.backend.chat_room.repository.ChatRoom;
 import com.sptp.backend.chat_room.repository.ChatRoomRepository;
 import com.sptp.backend.common.exception.CustomException;
@@ -10,7 +10,6 @@ import com.sptp.backend.member.repository.MemberRepository;
 import com.sptp.backend.message.repository.Message;
 import com.sptp.backend.message.repository.MessageRepository;
 import com.sptp.backend.message.web.dto.MessageRequest;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -23,8 +22,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -76,7 +73,7 @@ class MessageServiceTest {
             chatRoom = ChatRoom.builder()
                     .id(chatRoomId)
                     .artist(sender)
-                    .collector(receiver)
+                    .member(receiver)
                     .artWork(artWork)
                     .build();
 


### PR DESCRIPTION
## 📌 관련 이슈
#55 

## ✨ 작업 내용
- 채팅방 생성 api 구현
  - 기존에 채팅방이 존재하면 해당 채팅방의 id를 반환하고, 존재하지 않으면 신규 채팅방의 id를 반환
  - 요청 정상 처리 시 채팅방 조회 api로 리다이렉트
- 채팅방 조회 api 구현

## 📚 기타
- 채팅방 조회 api의 예상 응답시간은 추후 구현 예정
