### PR TITLE
Fix/122 fix bid

### DIFF
--- a/src/main/java/com/sptp/backend/art_work/service/ArtWorkService.java
+++ b/src/main/java/com/sptp/backend/art_work/service/ArtWorkService.java
@@ -147,7 +147,7 @@ public class ArtWorkService extends BaseEntity {
 
         Long topPrice = getTopPrice(artWork);
         Bidding bidding = biddingRepository.findByArtWorkAndMember(artWork, member)
-                .orElse(saveBidding(artWork, member));
+                .orElseGet(() -> saveBidding(artWork, member));
 
         bidding.raisePrice(topPrice, price);
     }

--- a/src/test/java/com/sptp/backend/art_work/service/ArtWorkServiceTest.java
+++ b/src/test/java/com/sptp/backend/art_work/service/ArtWorkServiceTest.java
@@ -24,6 +24,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -91,28 +92,27 @@ class ArtWorkServiceTest {
                     .build();
         }
 
-//        @ParameterizedTest(name = )
-//        void bid() {
-//            //given
-//            when(memberRepository.findById(memberId))
-//                    .thenReturn(Optional.of(member));
-//
-//            when(artWorkRepository.findById(artWorkId))
-//                    .thenReturn(Optional.of(artWork));
-//
-//            Long biddingId = 4L;
-//            Bidding.builder()
-//                            .id(biddingId)
-//                                    .artWork(artWork)
-//                                            .price()
-//            when(biddingRepository.save(any(Bidding.class)))
-//                    .thenReturn()
-//
-//
-//            //when
-//
-//            //then
-//        }
+        @Test
+        void bid() {
+            //given
+            bidding = Bidding.builder()
+                    .artWork(artWork)
+                    .createdDate(startDate)
+                    .build();
+
+            when(artWorkRepository.findById(anyLong()))
+                    .thenReturn(Optional.of(artWork));
+
+            when(memberRepository.findById(anyLong()))
+                    .thenReturn(Optional.of(member));
+
+            when(biddingRepository.save(any(Bidding.class)))
+                    .thenReturn(bidding);
+
+            //when
+            //then
+            assertThatNoException().isThrownBy(() -> artWorkService.bid(memberId, artWorkId, (long) (startPrice * 2)));
+        }
 
         @Test
         void failByNotFoundArtWork() {
@@ -229,9 +229,6 @@ class ArtWorkServiceTest {
 
             when(biddingRepository.findByArtWorkAndMember(any(ArtWork.class), any(Member.class)))
                     .thenReturn(Optional.of(bidding));
-
-            when(biddingRepository.save(any(Bidding.class)))
-                    .thenReturn(bidding);
 
             //when
             //then


### PR DESCRIPTION
## 📌 관련 이슈
#122 

## ✨ 작업 내용
- orElse -> orElseGet로 메서드 변경

## 📚 기타
- 결론부터 말하면 orElse는 null인 경우에도 else 부분을 실행하고, orElseGet은 지연로딩 방식으로 동작하기 떄문에 null인 경우에만 실행이 된다. 그로 인해 발생한 에러였다.
- 참고 링크
  - [orElse vs orElseGet](https://zgundam.tistory.com/174)
  - [Supplier](https://m.blog.naver.com/zzang9ha/222087025042)

