### PR TITLE
feat : admin 작가 전환 목록 조회시 연락처 데이터 추가

### DIFF
--- a/src/main/java/com/sptp/backend/member/service/MemberService.java
+++ b/src/main/java/com/sptp/backend/member/service/MemberService.java
@@ -309,7 +309,7 @@ public class MemberService {
         List<Member> findCertificationList = memberPreferredArtistRepository.findCertificationList();
 
         List<CertificationResponse> certificationResponses = findCertificationList.stream()
-                .map(m -> new CertificationResponse(m.getId(), processImage(m.getCertificationImage()), m.getRoles().get(0)))
+                .map(m -> new CertificationResponse(m.getId(), processImage(m.getCertificationImage()), m.getRoles().get(0), m.getTelephone()))
                 .collect(Collectors.toList());
 
         return certificationResponses;

--- a/src/main/java/com/sptp/backend/member/web/dto/response/CertificationResponse.java
+++ b/src/main/java/com/sptp/backend/member/web/dto/response/CertificationResponse.java
@@ -16,4 +16,5 @@ public class CertificationResponse {
     private Long id;
     private String certificationImage;
     private String roles;
+    private String telephone;
 }


### PR DESCRIPTION
## 📌 관련 이슈
close #198 
## ✨ 작업 내용
- 관리자 페이지에서 작가 전환 조회시에 전화번호 데이터 추가
## 📚 기타
